### PR TITLE
Possibly fixed NTLMv1 vs v2 test

### DIFF
--- a/rewrite.py
+++ b/rewrite.py
@@ -58,7 +58,7 @@ for challenge, response in pairs:
     nthash = binascii.b2a_hex(response[ntoff:ntoff+ntlen])
     domain = response[domoff:domoff+domlen].replace("\0", "")
     user = response[useroff:useroff+userlen].replace("\0", "")
-    if nthash == 24: #NTLM
+    if ntlen == 24: #NTLM
         print user+"::"+domain+":"+lmhash+":"+nthash+":"+serverchallenge
     else: #NTLMv2
         print user+"::"+domain+":"+serverchallenge+":"+nthash[:32]+":"+nthash[32:]

--- a/rewrite.py
+++ b/rewrite.py
@@ -58,7 +58,7 @@ for challenge, response in pairs:
     nthash = binascii.b2a_hex(response[ntoff:ntoff+ntlen])
     domain = response[domoff:domoff+domlen].replace("\0", "")
     user = response[useroff:useroff+userlen].replace("\0", "")
-    if len(nthash) == 24: #NTLM
+    if nthash == 24: #NTLM
         print user+"::"+domain+":"+lmhash+":"+nthash+":"+serverchallenge
     else: #NTLMv2
         print user+"::"+domain+":"+serverchallenge+":"+nthash[:32]+":"+nthash[32:]

--- a/rewrite.py
+++ b/rewrite.py
@@ -58,7 +58,7 @@ for challenge, response in pairs:
     nthash = binascii.b2a_hex(response[ntoff:ntoff+ntlen])
     domain = response[domoff:domoff+domlen].replace("\0", "")
     user = response[useroff:useroff+userlen].replace("\0", "")
-    if lmhash != "0"*48: #NTLM
+    if len(nthash) == 24: #NTLM
         print user+"::"+domain+":"+lmhash+":"+nthash+":"+serverchallenge
     else: #NTLMv2
         print user+"::"+domain+":"+serverchallenge+":"+nthash[:32]+":"+nthash[32:]


### PR DESCRIPTION
I was comparing your tool's output to Pcredz for a pcap and they ended up disagreeing about which version of NTLM the hash was. I checked Wikipedia and it says NTLMv1 is a fixed length hash of 24 bytes. I didn't do a ton of digging into why the method you're using might be wrong (I'm not 100% it is wrong, but I'm kinda sure).

```
if lmhash != "0"*48: #NTLMv1
```

But it seems to make sense to use something easier to understand like just checking the length of the NT hash to make an accurate check for v2 vs. v1.

```
if ntlen == 24: #NTLMv1
```